### PR TITLE
Deleted bshell/bshell.bat

### DIFF
--- a/bshell/bshell.bat
+++ b/bshell/bshell.bat
@@ -1,3 +1,0 @@
-@echo off
-python.exe "bshell/Bshell_code/bshell.py"
-pause


### PR DESCRIPTION
This is because you can directly run the python file with python.